### PR TITLE
15 read pending payments

### DIFF
--- a/src/payment/payment.controller.ts
+++ b/src/payment/payment.controller.ts
@@ -6,7 +6,7 @@ import {
   Query,
 } from '@nestjs/common';
 import { PaymentService } from './payment.service';
-import { Payment } from '@prisma/client';
+import { Student } from '@prisma/client';
 
 @Controller('payment')
 export class PaymentController {
@@ -15,30 +15,9 @@ export class PaymentController {
   @Get('accepted')
   async GetAllAcceptedPayments(
     @Query('page') page: number,
-  ): Promise<Payment[]> {
+  ): Promise<Student[]> {
     try {
       return this.paymentService.findAllAcceptedPayments(page);
-    } catch (error) {
-      throw new HttpException(
-        {
-          status: HttpStatus.FORBIDDEN,
-          error: 'Something went wrong',
-        },
-        HttpStatus.FORBIDDEN,
-        {
-          cause: error,
-        },
-      );
-    }
-  }
-
-  @Get('declined')
-  async GetAllDeclinedPayments(
-    @Query('page') page: number,
-  ): Promise<Payment[]> {
-    try {
-      return this.paymentService.findAllDeclinedPayments(page);
-
     } catch (error) {
       throw new HttpException(
         {

--- a/src/payment/payment.controller.ts
+++ b/src/payment/payment.controller.ts
@@ -51,4 +51,22 @@ export class PaymentController {
       );
     }
   }
+
+  @Get('pending')
+  async GetAllPendingPayments(@Query('page') page: number): Promise<Student[]> {
+    try {
+      return this.paymentService.findAllPendingPayments(page);
+    } catch (error) {
+      throw new HttpException(
+        {
+          status: HttpStatus.FORBIDDEN,
+          error: 'Something went wrong',
+        },
+        HttpStatus.FORBIDDEN,
+        {
+          cause: error,
+        },
+      );
+    }
+  }
 }

--- a/src/payment/payment.controller.ts
+++ b/src/payment/payment.controller.ts
@@ -31,4 +31,24 @@ export class PaymentController {
       );
     }
   }
+
+  @Get('declined')
+  async GetAllDeclinedPayments(
+    @Query('page') page: number,
+  ): Promise<Student[]> {
+    try {
+      return this.paymentService.findAllDeclinedPayments(page);
+    } catch (error) {
+      throw new HttpException(
+        {
+          status: HttpStatus.FORBIDDEN,
+          error: 'Something went wrong',
+        },
+        HttpStatus.FORBIDDEN,
+        {
+          cause: error,
+        },
+      );
+    }
+  }
 }

--- a/src/payment/payment.service.ts
+++ b/src/payment/payment.service.ts
@@ -15,7 +15,7 @@ export class PaymentService {
       where: {
         payment: {
           status: 'accepted',
-        }
+        },
       },
       take: items,
       skip: items * (page - 1),
@@ -31,11 +31,26 @@ export class PaymentService {
       where: {
         payment: {
           status: 'declined',
-        }
+        },
       },
       take: items,
       skip: items * (page - 1),
     });
   }
 
+  async findAllPendingPayments(page = 1, items = 10): Promise<Student[]> {
+    return this.prisma.student.findMany({
+      include: {
+        payment: {},
+        event: {},
+      },
+      where: {
+        payment: {
+          status: 'pending',
+        },
+      },
+      take: items,
+      skip: items * (page - 1),
+    });
+  }
 }

--- a/src/payment/payment.service.ts
+++ b/src/payment/payment.service.ts
@@ -1,22 +1,22 @@
 import { Injectable } from '@nestjs/common';
-import { Payment } from '@prisma/client';
+import { Student } from '@prisma/client';
 import { PrismaService } from 'src/prisma/prisma.service';
 
 @Injectable()
 export class PaymentService {
   constructor(private prisma: PrismaService) {}
 
-  async findAllAcceptedPayments(page = 1, items = 10): Promise<Payment[]> {
-    return this.prisma.payment.findMany({
-      where: { status: 'accepted' },
-      take: items,
-      skip: items * (page - 1),
-    });
-  }
-
-  async findAllDeclinedPayments(page = 1, items = 10): Promise<Payment[]> {
-    return this.prisma.payment.findMany({
-      where: { status: 'declined' },
+  async findAllAcceptedPayments(page = 1, items = 10): Promise<Student[]> {
+    return this.prisma.student.findMany({
+      include: {
+        payment: {},
+        event: {},
+      },
+      where: {
+        payment: {
+          status: 'accepted',
+        }
+      },
       take: items,
       skip: items * (page - 1),
     });

--- a/src/payment/payment.service.ts
+++ b/src/payment/payment.service.ts
@@ -22,4 +22,20 @@ export class PaymentService {
     });
   }
 
+  async findAllDeclinedPayments(page = 1, items = 10): Promise<Student[]> {
+    return this.prisma.student.findMany({
+      include: {
+        payment: {},
+        event: {},
+      },
+      where: {
+        payment: {
+          status: 'declined',
+        }
+      },
+      take: items,
+      skip: items * (page - 1),
+    });
+  }
+
 }


### PR DESCRIPTION
- /payment/accepted, /payment/declined, and /payment/pending endpoints can now be viewed
- Retrieve all accepted, declined, and pending payments, including associated events and students
- Added pagination with 10 data entries per page.
- Should return the following:

![image](https://github.com/SAMAHAN-Systems-Development/ACMS-backend-2023/assets/62329819/051920b3-9ccf-4aa1-90cd-2731503fdaac)
