### PR TITLE
feat(event): read inactive events

### DIFF
--- a/src/event/event.controller.ts
+++ b/src/event/event.controller.ts
@@ -6,7 +6,6 @@ import {
   Param,
   ParseIntPipe,
   Patch,
-  Get,
   Query,
 } from '@nestjs/common';
 import { EventService } from './event.service';
@@ -58,6 +57,24 @@ export class EventController {
   async getActiveEvents(@Query('page') page: number): Promise<Event[]> {
     try {
       return await this.eventService.getActiveEvents(page);
+    } catch (error) {
+      throw new HttpException(
+        {
+          status: HttpStatus.FORBIDDEN,
+          error: 'Something went wrong',
+        },
+        HttpStatus.FORBIDDEN,
+        {
+          cause: error,
+        },
+      );
+    }
+  }
+
+  @Get('inactive')
+  async getInactiveEvents(@Query('page') page: number): Promise<Event[]> {
+    try {
+      return await this.eventService.getInactiveEvents(page);
     } catch (error) {
       throw new HttpException(
         {

--- a/src/event/event.service.ts
+++ b/src/event/event.service.ts
@@ -44,4 +44,12 @@ export class EventService {
       skip: items * (page - 1),
     });
   }
+
+  async getInactiveEvents(page = 1, items = 10): Promise<Event[]> {
+    return this.prismaService.event.findMany({
+      where: { is_active: false },
+      take: items,
+      skip: items * (page - 1),
+    });
+  }
 }


### PR DESCRIPTION
- Working /event/inactive endpoint
- Should return list of inactive events
- When error 403 occurs:
```
Something went wrong.
```