### PR TITLE
feat: adds endpoints to get payments attached to event

### DIFF
--- a/src/event/event.controller.ts
+++ b/src/event/event.controller.ts
@@ -6,7 +6,6 @@ import {
   Param,
   ParseIntPipe,
   Patch,
-  Get,
   Query,
 } from '@nestjs/common';
 import { EventService } from './event.service';

--- a/src/payment/payment.controller.ts
+++ b/src/payment/payment.controller.ts
@@ -54,6 +54,20 @@ export class PaymentController {
     }
   }
 
+  @Get('declined/:id')
+  async getEventDeclinedPayments(
+    @Param('id', ParseIntPipe) eventId: number,
+    @Query('page') page: number,
+  ): Promise<Student[]> {
+    try {
+      return await this.paymentService.getEventDeclinedPayments(eventId, page);
+    } catch (error) {
+      throw new HttpException('Something went wrong', HttpStatus.BAD_REQUEST, {
+        cause: error,
+      });
+    }
+  }
+
   @Get('pending')
   async getAllPendingPayments(@Query('page') page: number): Promise<Student[]> {
     try {
@@ -75,7 +89,7 @@ export class PaymentController {
   @Get('pending/:id')
   async getEventPendingPayments(
     @Param('id', ParseIntPipe) eventId: number,
-    @Query('page', ParseIntPipe) page: number,
+    @Query('page') page: number,
   ) {
     try {
       return await this.paymentService.getEventPendingPayments(eventId, page);

--- a/src/payment/payment.controller.ts
+++ b/src/payment/payment.controller.ts
@@ -34,6 +34,20 @@ export class PaymentController {
     }
   }
 
+  @Get('accepted/:id')
+  async getEventAcceptedPayments(
+    @Param('id', ParseIntPipe) eventId: number,
+    @Query('page') page: number,
+  ): Promise<Student[]> {
+    try {
+      return await this.paymentService.getEventAcceptedPayments(eventId, page);
+    } catch (error) {
+      throw new HttpException('Something went wrong', HttpStatus.BAD_REQUEST, {
+        cause: error,
+      });
+    }
+  }
+
   @Get('declined')
   async getAllDeclinedPayments(
     @Query('page') page: number,

--- a/src/payment/payment.controller.ts
+++ b/src/payment/payment.controller.ts
@@ -3,6 +3,8 @@ import {
   Get,
   HttpException,
   HttpStatus,
+  Param,
+  ParseIntPipe,
   Query,
 } from '@nestjs/common';
 import { PaymentService } from './payment.service';
@@ -67,6 +69,20 @@ export class PaymentController {
           cause: error,
         },
       );
+    }
+  }
+
+  @Get('pending/:id')
+  async getEventPendingPayments(
+    @Param('id', ParseIntPipe) eventId: number,
+    @Query('page', ParseIntPipe) page: number,
+  ) {
+    try {
+      return await this.paymentService.getEventPendingPayments(eventId, page);
+    } catch (error) {
+      throw new HttpException('Something went wrong', HttpStatus.BAD_REQUEST, {
+        cause: error,
+      });
     }
   }
 }

--- a/src/payment/payment.service.ts
+++ b/src/payment/payment.service.ts
@@ -38,6 +38,33 @@ export class PaymentService {
     });
   }
 
+  async getEventDeclinedPayments(
+    eventId: number,
+    page = 1,
+    items = 10,
+  ): Promise<Student[]> {
+    const skipItems = items * (page - 1);
+
+    const pendingPayments = await this.prisma.student.findMany({
+      include: {
+        event: true,
+        payment: true,
+      },
+      where: {
+        event: {
+          id: eventId,
+        },
+        payment: {
+          status: 'declined',
+        },
+      },
+      take: items,
+      skip: skipItems,
+    });
+
+    return pendingPayments;
+  }
+
   async getAllPendingPayments(page = 1, items = 10): Promise<Student[]> {
     return this.prisma.student.findMany({
       include: {

--- a/src/payment/payment.service.ts
+++ b/src/payment/payment.service.ts
@@ -53,4 +53,31 @@ export class PaymentService {
       skip: items * (page - 1),
     });
   }
+
+  async getEventPendingPayments(
+    eventId: number,
+    page = 1,
+    items = 10,
+  ): Promise<Student[]> {
+    const skipItems = items * (page - 1);
+
+    const pendingPayments = await this.prisma.student.findMany({
+      include: {
+        event: true,
+        payment: true,
+      },
+      where: {
+        event: {
+          id: eventId,
+        },
+        payment: {
+          status: 'pending',
+        },
+      },
+      take: items,
+      skip: skipItems,
+    });
+
+    return pendingPayments;
+  }
 }

--- a/src/payment/payment.service.ts
+++ b/src/payment/payment.service.ts
@@ -22,6 +22,33 @@ export class PaymentService {
     });
   }
 
+  async getEventAcceptedPayments(
+    eventId: number,
+    page = 1,
+    items = 10,
+  ): Promise<Student[]> {
+    const skipItems = items * (page - 1);
+
+    const acceptedPayments = await this.prisma.student.findMany({
+      include: {
+        event: true,
+        payment: true,
+      },
+      where: {
+        event: {
+          id: eventId,
+        },
+        payment: {
+          status: 'accepted',
+        },
+      },
+      take: items,
+      skip: skipItems,
+    });
+
+    return acceptedPayments;
+  }
+
   async getAllDeclinedPayments(page = 1, items = 10): Promise<Student[]> {
     return this.prisma.student.findMany({
       include: {
@@ -45,7 +72,7 @@ export class PaymentService {
   ): Promise<Student[]> {
     const skipItems = items * (page - 1);
 
-    const pendingPayments = await this.prisma.student.findMany({
+    const declinedPayments = await this.prisma.student.findMany({
       include: {
         event: true,
         payment: true,
@@ -62,7 +89,7 @@ export class PaymentService {
       skip: skipItems,
     });
 
-    return pendingPayments;
+    return declinedPayments;
   }
 
   async getAllPendingPayments(page = 1, items = 10): Promise<Student[]> {


### PR DESCRIPTION
- Adds the following endpoints (ID must be int/number):
     - ***"/payment/pending/{id}"*** - retrieves all pending payments for a specified event
     - ***"/payment/accepted/{id}"*** - retrieves all accepted payments for a specified event
     - ***"/payment/declined/{id}"*** - retrieves all declined payments for a specified event
-  All endpoints accept a "page" query param, which must be int/number
     - Is used for pagination. Each page returns 10 items per page as default
- returns a list of payments
     - Ex:

```JSON
[
    {
        "id": 9,
        "createdAt": "2024-01-08T17:29:06.302Z",
        "updatedAt": "2024-01-09T01:00:00.000Z",
        "uuid": "crst",
        "firstName": "crst",
        "lastName": "crst",
        "email": "crst@crsetncierst.com",
        "year_and_course": "crst",
        "paymentId": 7,
        "eventId": 10,
        "event": {
            "id": 10,
            "createdAt": "2023-12-30T16:22:37.848Z",
            "updatedAt": "2023-12-30T16:22:37.848Z",
            "title": "careo sophismata error comburo beatae adeo",
            "price": "Php134.00",
            "requires_payment": true,
            "max_participants": 55,
            "description": "Teres umbra caelestis rerum taceo tenetur aqua vilicus strenuus. Nam conduco perferendis abeo urbanus perspiciatis. Valde vulnero teneo.\nMolestias audax deserunt condico summopere velum. In depopulo non cultura. Stella voluptatibus volo adimpleo curso cohaero creta tubineus.\nValetudo clarus totus stipes votum cras audio vinum contego. Conicio cetera aer vesper decor volubilis apud. Arcus coadunatio nemo summisse veritatis brevis voveo canonicus animadverto beatae.",
            "date": "2024-03-14T06:06:58.987Z",
            "is_active": true,
            "form_name": "eos odio eligendi cursim sollicito beneficium"
        },
        "payment": {
            "id": 7,
            "createdAt": "2024-01-08T17:28:17.221Z",
            "updatedAt": "2024-01-09T01:00:00.000Z",
            "photo_src": "link/to/payment/receipt.jpg",
            "status": "accepted"
        }
    }
]
```

- if the request was unsuccessful, it will return the following:
```JSON
{
     statusCode: 400,
     message: "Something went wrong"
}
```